### PR TITLE
Ignore non-word characters in slugs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,14 @@ class ApplicationController < ActionController::Base
   protect_from_forgery # :secret => '5ee0c1f9ce72a776ebba8a8c3338e3d2'
 
   expose(:current_period) { params[:period].present? ? params[:period] : 'hour' }
-  expose(:current_vurl) { params[:slug] ? Vurl.find_by_slug(params[:slug]) : Vurl.find_by_id(params[:id]) }
+  expose(:current_vurl) do
+    if slug = params[:slug]
+      slug = slug[/^\w+/]
+      Vurl.find_by_slug(slug)
+    else
+      Vurl.find_by_id(params[:id])
+    end
+  end
   expose(:authlogic_user_session) { UserSession.find }
 
   protected

--- a/spec/controllers/vurls_controller_spec.rb
+++ b/spec/controllers/vurls_controller_spec.rb
@@ -62,6 +62,10 @@ describe VurlsController do
       before do
         Vurl.stub!(:find_by_slug).and_return(vurl)
       end
+      it "redirects to the vurl's url" do
+        get :redirect, :slug => vurl.slug
+        response.should redirect_to(vurl.url)
+      end
       it "creates a click" do
         Click.should_receive(:new).with(:vurl => vurl, :ip_address => '0.0.0.0', :user_agent => 'Rails Testing', :referer => nil).and_return(mock('click', :save => true))
         get :redirect, :slug => 'AA'
@@ -72,6 +76,14 @@ describe VurlsController do
         Click.stub!(:new).and_return(click)
         controller.logger.should_receive(:warn).with("Couldn't create Click for Vurl (#{vurl.inspect}) because it had the following errors: #{click.errors}")
         get :redirect, :slug => 'some slug'
+      end
+    end
+
+    describe "when the slug contains non-slug characters" do
+      it "finds the vurl only by the slug characters" do
+        Vurl.should_receive(:find_by_slug).with("AAA").and_return(vurl)
+        get :redirect, :slug => "AAA,"
+        response.should redirect_to(vurl.url)
       end
     end
 


### PR DESCRIPTION
This is helps those of us who might tweet, "Is it at http://vurl.me/AAA,
BBB, or somewhere else?" Twitter will include the comma above in the
URL, so vurl should just ignore it.
